### PR TITLE
fix poseidon output

### DIFF
--- a/ecc/bn254/fr/poseidon/poseidon.go
+++ b/ecc/bn254/fr/poseidon/poseidon.go
@@ -139,7 +139,7 @@ func Poseidon(input ...*fr.Element) *fr.Element {
 		deepCopy(state[1:], input[startIndex:lastIndex])
 		state = permutation(state[:remainigLength+1])
 	}
-	return state[0]
+	return state[1]
 }
 
 func PoseidonBytes(input ...[]byte) []byte {

--- a/ecc/bn254/fr/poseidon/poseidon_test.go
+++ b/ecc/bn254/fr/poseidon/poseidon_test.go
@@ -21,7 +21,7 @@ func elementFromHexString(v string) *fr.Element {
 func TestPoseidonTwo(t *testing.T) {
 	// Test vector https://extgit.iaik.tugraz.at/krypto/hadeshash/-/blob/master/code/test_vectors.txt
 	inputsStr := []string{"1", "2"}
-	expectedHash := elementFromHexString("115cc0f5e7d690413df64c6b9662e9cf2a3617f2743245519e19607a4417189a")
+	expectedHash := elementFromHexString("FCA49B798923AB0239DE1C9E7A4A9A2210312B6A2F616D18B5A87F9B628AE29")
 	inputs := make([]*fr.Element, len(inputsStr))
 	for i := 0; i < len(inputsStr); i++ {
 		inputs[i] = elementFromHexString(inputsStr[i])
@@ -33,7 +33,7 @@ func TestPoseidonTwo(t *testing.T) {
 func TestPoseidonFour(t *testing.T) {
 	// Test vector https://extgit.iaik.tugraz.at/krypto/hadeshash/-/blob/master/code/test_vectors.txt
 	inputsStr := []string{"1", "2", "3", "4"}
-	expectedHash := elementFromHexString("299c867db6c1fdd79dcefa40e4510b9837e60ebb1ce0663dbaa525df65250465")
+	expectedHash := elementFromHexString("1148AAEF609AA338B27DAFD89BB98862D8BB2B429ACEAC47D86206154FFE053D")
 	inputs := make([]*fr.Element, len(inputsStr))
 	for i := 0; i < len(inputsStr); i++ {
 		inputs[i] = elementFromHexString(inputsStr[i])
@@ -44,7 +44,7 @@ func TestPoseidonFour(t *testing.T) {
 
 func TestPoseidon24(t *testing.T) {
 	// WARNING: No test vector to compare with
-	expectedHash := elementFromHexString("612D378F91DC3422E6C60E54D24E3FA6D8000F0E47CDACE9BDB304506E3C9D3")
+	expectedHash := elementFromHexString("6C7676E83EF8CB9EF6C25746A5F6B2D39FBA4548B4C29B3D41490BBF3C1108D")
 	length := 24
 	inputs := make([]*fr.Element, length)
 	for i := 0; i < length; i++ {
@@ -57,7 +57,7 @@ func TestPoseidon24(t *testing.T) {
 
 func TestPoseidonThirty(t *testing.T) {
 	// WARNING: No test vector to compare with
-	expectedHash := elementFromHexString("140CEA90C05A04C7140337789BD4CDE38BA73EE1988D34533F3F8F7B6AAC5675")
+	expectedHash := elementFromHexString("2FF47AB8E9E9F6134600A8DE8B8E99596E573620A7D8D39ED7B2C7CEF9F105F1")
 	length := 30
 	inputs := make([]*fr.Element, length)
 	for i := 0; i < length; i++ {
@@ -83,7 +83,7 @@ func TestConsistency(t *testing.T) {
 
 func TestPoseidonBytes(t *testing.T) {
 	// Test vector https://extgit.iaik.tugraz.at/krypto/hadeshash/-/blob/master/code/test_vectors.txt
-	expectedHash := elementFromHexString("115cc0f5e7d690413df64c6b9662e9cf2a3617f2743245519e19607a4417189a")
+	expectedHash := elementFromHexString("FCA49B798923AB0239DE1C9E7A4A9A2210312B6A2F616D18B5A87F9B628AE29")
 	inputs := make([][]byte, 2)
 	inputs[0] = make([]byte, 1)
 	inputs[0][0] = 1
@@ -96,7 +96,7 @@ func TestPoseidonBytes(t *testing.T) {
 }
 
 func TestDigest(t *testing.T) {
-	expectedHash := elementFromHexString("115cc0f5e7d690413df64c6b9662e9cf2a3617f2743245519e19607a4417189a")
+	expectedHash := elementFromHexString("FCA49B798923AB0239DE1C9E7A4A9A2210312B6A2F616D18B5A87F9B628AE29")
 	hFunc := NewPoseidon()
 	inputs := make([][]byte, 2)
 	inputs[0] = make([]byte, 1)


### PR DESCRIPTION
This PR fixes one issue:

1. Return the first element of rate (i.e., state[1]) in sponge construction as the hash output rather than the capacity element (i.e. state[0])